### PR TITLE
Add offline PWA test

### DIFF
--- a/tests/pwa-offline.test.js
+++ b/tests/pwa-offline.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const BUILD_DIR = '.output/public';
+
+function buildProject() {
+  execSync('npx nuxi build', { stdio: 'ignore' });
+}
+
+test('PWA runs offline after first download', () => {
+  buildProject();
+  const swPath = `${BUILD_DIR}/sw.js`;
+  assert.ok(fs.existsSync(swPath), 'service worker not found');
+
+  const swContent = fs.readFileSync(swPath, 'utf8');
+  assert.match(swContent, /precacheAndRoute/);
+  assert.match(swContent, /NavigationRoute/);
+});


### PR DESCRIPTION
## Summary
- add a node test that builds the Nuxt app and checks the generated service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b7eb10d38833396d7ed8a67028ef0