### PR TITLE
Add production steps test

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@
   </main>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 const isOnline = ref(true)

--- a/tests/production.test.js
+++ b/tests/production.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { execSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+
+const BUILD_DIR = '.output'
+const GENERATE_DIR = 'docs'
+
+test('README production steps work', async () => {
+  // Build the application
+  execSync('npm run build', { stdio: 'inherit' });
+  assert.ok(fs.existsSync(BUILD_DIR), 'build output missing');
+
+  // Generate the static site
+  execSync('npm run generate', { stdio: 'inherit' });
+  assert.ok(fs.existsSync(`${GENERATE_DIR}/index.html`), 'generated index.html missing');
+
+  // Preview command is available
+  const result = spawnSync('npm', ['run', 'preview', '--', '--help'], {
+    stdio: 'inherit'
+  })
+  assert.strictEqual(result.status, 0, 'preview command failed')
+});


### PR DESCRIPTION
## Summary
- ensure TypeScript in `<script setup>` for `pages/index.vue`
- add a test verifying README production steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b96af21988333b73c8f77783fc401