### PR TITLE
Implement memory guardrails and update scripts

### DIFF
--- a/OFFLINE_USAGE.md
+++ b/OFFLINE_USAGE.md
@@ -6,4 +6,4 @@ The BrainPDF application is designed to work even without network connectivity. 
 2. Use your browser's developer tools to simulate going offline.
 3. Refresh the page. The application should continue to load and allow you to interact with it without errors.
 
-For an automated check run `npm test`. The `pwa-offline.test.js` script ensures the generated files contain the service worker configuration required for offline operation.
+For an automated check run `pnpm test`. The `pwa-offline.test.js` script ensures the generated files contain the service worker configuration required for offline operation.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,10 @@ This repository contains the generated static output in the `docs/` directory so
 
 ## Setup
 
-Install dependencies with your preferred package manager:
+Install dependencies using pnpm:
 
 ```bash
-# npm
-npm install
-
-# pnpm
 pnpm install
-
-# yarn
-yarn install
-
-# bun
-bun install
 ```
 
 ## Development
@@ -27,7 +17,7 @@ bun install
 Run the development server at `http://localhost:3000`:
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 ## Production
@@ -35,19 +25,19 @@ npm run dev
 Build the application for production:
 
 ```bash
-npm run build
+pnpm run build
 ```
 
 Generate the static site (output in `docs/`):
 
 ```bash
-npm run generate
+pnpm run generate
 ```
 
 Preview the production build locally:
 
 ```bash
-npm run preview
+pnpm run preview
 ```
 
 ## Offline usage
@@ -61,7 +51,7 @@ npm run preview
 Run the test suite with:
 
 ```bash
-npm test
+pnpm test
 ```
 
 The tests verify that the generated output contains a service worker with Workbox caching rules so the application can run offline after the first visit.

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,69 +1,180 @@
 <template>
-  <main class="p-8">
-    <h1 class="text-2xl font-bold mb-4">BrainPDF Offline Demo</h1>
-    <p class="mb-2">This homepage demonstrates the PWA's offline capability.</p>
+  <main class="p-8 text-center">
+    <h1 class="text-2xl font-bold mb-4">BrainPDF Demo</h1>
+    <p class="mb-2">Local-first PDF toolkit running entirely in the browser.</p>
     <p>Status: <span :class="statusClass">{{ onlineStatus }}</span></p>
+    <p class="mt-2">Available memory: {{ availableMemoryMB }} MB</p>
+    <p>Max PDF size: {{ maxPdfSizeMB }} MB</p>
 
-    <div class="mt-4">
-      <input type="file" accept="application/pdf" @change="handleFile" />
-      <button
-        v-if="downloadUrl"
-        @click="triggerDownload"
-        class="mt-2 px-4 py-2 bg-blue-500 text-white rounded"
-      >
-        Download PDF
-      </button>
+    <div
+      class="border-dashed border-2 p-4 mt-4 cursor-pointer"
+      @click="openFilePicker"
+      @drop.prevent="onDrop"
+      @dragover.prevent
+    >
+      <p v-if="!selectedFile">Drop PDF here or click to select</p>
+      <p v-else>{{ selectedFile.name }} ({{ (selectedFile.size/1024/1024).toFixed(1) }} MB)</p>
+      <input ref="fileInput" type="file" accept="application/pdf" class="hidden" @change="handleFile" />
+    </div>
+    <div v-if="fileTooLarge" class="text-red-600 mt-2">File exceeds maximum allowed size.</div>
+
+    <div v-if="selectedFile && !fileTooLarge" class="mt-4">
+      <div v-if="progress < 100">
+        <p>Parsing... {{ progress }}%</p>
+        <div class="w-full bg-gray-200 h-2">
+          <div class="bg-blue-500 h-2" :style="{ width: progress + '%' }"></div>
+        </div>
+      </div>
+      <div v-else>
+        <div class="flex items-center mb-2 justify-center">
+          <label class="mr-2">Split method:</label>
+          <select v-model="splitMode" class="border">
+            <option value="equal">Equal parts</option>
+            <option value="size">Chunk size (MB)</option>
+          </select>
+        </div>
+        <div v-if="splitMode === 'equal'" class="mb-2">
+          <label>Parts:</label>
+          <input type="number" v-model.number="equalParts" min="1" class="border w-16 ml-2" />
+        </div>
+        <div v-else class="mb-2">
+          <label>Size(MB):</label>
+          <input type="number" v-model.number="chunkSize" min="1" class="border w-16 ml-2" />
+        </div>
+        <button class="px-4 py-2 bg-green-500 text-white rounded" @click="splitFile">Split</button>
+      </div>
+
+      <div v-if="sections.length > 0" class="mt-4 text-left">
+        <h2 class="font-semibold mb-2">Sections</h2>
+        <div v-for="(sec, index) in sections" :key="index" class="flex items-center mb-1">
+          <input type="checkbox" v-model="selectedSections" :value="index" class="mr-2" />
+          <span>{{ sec.name }}</span>
+        </div>
+        <button class="mt-2 px-4 py-2 bg-blue-500 text-white rounded" @click="exportSections" :disabled="selectedSections.length === 0">Export</button>
+      </div>
     </div>
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { getAvailableMemoryMB, computeMaxPdfSizeMB } from '~/utils/memory'
+import { createZip } from '~/utils/zip'
 
 const isOnline = ref(true)
+const fileInput = ref<HTMLInputElement | null>(null)
 const selectedFile = ref<File | null>(null)
-const downloadUrl = ref<string | null>(null)
+const fileData = ref<Uint8Array | null>(null)
+const progress = ref(0)
+const fileTooLarge = ref(false)
+
+const splitMode = ref<'equal' | 'size'>('equal')
+const equalParts = ref(2)
+const chunkSize = ref(1)
+const sections = ref<{ name: string; data: Uint8Array }[]>([])
+const selectedSections = ref<number[]>([])
+
+const availableMemoryMB = ref(0)
+const maxPdfSizeMB = ref(0)
+
 const update = () => { isOnline.value = navigator.onLine }
-
-const handleFile = (event: Event) => {
-  const files = (event.target as HTMLInputElement).files
-  if (files && files[0]) {
-    selectedFile.value = files[0]
-    if (downloadUrl.value) {
-      URL.revokeObjectURL(downloadUrl.value)
-    }
-    downloadUrl.value = URL.createObjectURL(files[0])
-  } else {
-    selectedFile.value = null
-    if (downloadUrl.value) {
-      URL.revokeObjectURL(downloadUrl.value)
-    }
-    downloadUrl.value = null
-  }
-}
-
-const triggerDownload = () => {
-  if (downloadUrl.value) {
-    const link = document.createElement('a')
-    link.href = downloadUrl.value
-    link.download = selectedFile.value?.name || 'file.pdf'
-    link.click()
-  }
-}
 
 onMounted(() => {
   update()
   window.addEventListener('online', update)
   window.addEventListener('offline', update)
+  availableMemoryMB.value = getAvailableMemoryMB()
+  maxPdfSizeMB.value = computeMaxPdfSizeMB(availableMemoryMB.value)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('online', update)
   window.removeEventListener('offline', update)
-  if (downloadUrl.value) {
-    URL.revokeObjectURL(downloadUrl.value)
-  }
 })
+
+const openFilePicker = () => {
+  fileInput.value?.click()
+}
+
+const handleFile = (event: Event) => {
+  const files = (event.target as HTMLInputElement).files
+  if (files && files[0]) {
+    selectedFile.value = files[0]
+    fileTooLarge.value = files[0].size / (1024 * 1024) > maxPdfSizeMB.value
+    if (!fileTooLarge.value) parseFile()
+  }
+}
+
+const onDrop = (e: DragEvent) => {
+  const files = e.dataTransfer?.files
+  if (files && files[0]) {
+    const ev = { target: { files } } as unknown as Event
+    handleFile(ev)
+  }
+}
+
+function parseFile() {
+  if (!selectedFile.value) return
+  progress.value = 0
+  const reader = new FileReader()
+  reader.onprogress = (e) => {
+    if (e.lengthComputable) {
+      progress.value = Math.round((e.loaded / e.total) * 100)
+    }
+  }
+  reader.onload = () => {
+    progress.value = 100
+    fileData.value = new Uint8Array(reader.result as ArrayBuffer)
+  }
+  reader.readAsArrayBuffer(selectedFile.value)
+}
+
+function splitFile() {
+  if (!fileData.value) return
+  const data = fileData.value
+  sections.value = []
+  selectedSections.value = []
+  if (splitMode.value === 'equal') {
+    const n = Math.max(1, equalParts.value)
+    const partSize = Math.ceil(data.length / n)
+    for (let i = 0; i < n; i++) {
+      const start = i * partSize
+      const end = Math.min(start + partSize, data.length)
+      const slice = data.slice(start, end)
+      sections.value.push({ name: `section-${i + 1}.pdf`, data: slice })
+    }
+  } else {
+    const sizeBytes = Math.max(1, chunkSize.value) * 1024 * 1024
+    let offset = 0
+    let idx = 1
+    while (offset < data.length) {
+      const slice = data.slice(offset, offset + sizeBytes)
+      sections.value.push({ name: `section-${idx}.pdf`, data: slice })
+      offset += sizeBytes
+      idx++
+    }
+  }
+}
+
+function exportSections() {
+  const files = selectedSections.value.map(i => sections.value[i])
+  if (files.length === 1) {
+    const blob = new Blob([files[0].data], { type: 'application/pdf' })
+    downloadBlob(blob, files[0].name)
+  } else if (files.length > 1) {
+    const zipBlob = createZip(files.map(f => ({ name: f.name, data: f.data })))
+    downloadBlob(zipBlob, 'sections.zip')
+  }
+}
+
+function downloadBlob(blob: Blob, name: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = name
+  a.click()
+  URL.revokeObjectURL(url)
+}
 
 const onlineStatus = computed(() => (isOnline.value ? 'Online' : 'Offline'))
 const statusClass = computed(() => (isOnline.value ? 'text-green-600' : 'text-red-600'))
@@ -73,6 +184,5 @@ const statusClass = computed(() => (isOnline.value ? 'text-green-600' : 'text-re
 main {
   max-width: 600px;
   margin: 0 auto;
-  text-align: center;
 }
 </style>

--- a/tests/production.test.js
+++ b/tests/production.test.js
@@ -8,15 +8,15 @@ const GENERATE_DIR = 'docs'
 
 test('README production steps work', async () => {
   // Build the application
-  execSync('npm run build', { stdio: 'inherit' });
+  execSync('pnpm run build', { stdio: 'inherit' });
   assert.ok(fs.existsSync(BUILD_DIR), 'build output missing');
 
   // Generate the static site
-  execSync('npm run generate', { stdio: 'inherit' });
+  execSync('pnpm run generate', { stdio: 'inherit' });
   assert.ok(fs.existsSync(`${GENERATE_DIR}/index.html`), 'generated index.html missing');
 
   // Preview command is available
-  const result = spawnSync('npm', ['run', 'preview', '--', '--help'], {
+  const result = spawnSync('pnpm', ['run', 'preview', '--', '--help'], {
     stdio: 'inherit'
   })
   assert.strictEqual(result.status, 0, 'preview command failed')

--- a/utils/memory.ts
+++ b/utils/memory.ts
@@ -1,0 +1,14 @@
+export function getAvailableMemoryMB(): number {
+  const mem = (navigator as any).deviceMemory
+  // navigator.deviceMemory reports in GB when available
+  if (typeof mem === 'number') {
+    return Math.round(mem * 1024)
+  }
+  // Fallback when API unsupported
+  return 2048
+}
+
+export function computeMaxPdfSizeMB(totalMemMB: number): number {
+  // Assume we need roughly twice the PDF size in memory for parsing
+  return Math.floor(totalMemMB / 2)
+}

--- a/utils/zip.ts
+++ b/utils/zip.ts
@@ -1,0 +1,101 @@
+export interface ZipEntry {
+  name: string
+  data: Uint8Array
+}
+
+// CRC32 table for polynomial 0xEDB88320
+const crcTable = (() => {
+  const table = new Uint32Array(256)
+  for (let i = 0; i < 256; i++) {
+    let c = i
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    }
+    table[i] = c >>> 0
+  }
+  return table
+})()
+
+function crc32(data: Uint8Array): number {
+  let c = 0xffffffff
+  for (let i = 0; i < data.length; i++) {
+    c = crcTable[(c ^ data[i]) & 0xff] ^ (c >>> 8)
+  }
+  return (c ^ 0xffffffff) >>> 0
+}
+
+/**
+ * Create a minimal ZIP archive containing the provided files.
+ * Files are stored uncompressed to keep implementation small.
+ */
+export function createZip(entries: ZipEntry[]): Blob {
+  const localParts: Uint8Array[] = []
+  const centralParts: Uint8Array[] = []
+  const encoder = new TextEncoder()
+  let offset = 0
+
+  const now = new Date()
+  const modTime = ((now.getHours() << 11) | (now.getMinutes() << 5) | (now.getSeconds() / 2)) & 0xffff
+  const modDate = (((now.getFullYear() - 1980) << 9) | ((now.getMonth() + 1) << 5) | now.getDate()) & 0xffff
+
+  for (const entry of entries) {
+    const nameBuf = encoder.encode(entry.name)
+    const data = entry.data
+    const crc = crc32(data)
+
+    const local = new Uint8Array(30 + nameBuf.length)
+    const lv = new DataView(local.buffer)
+    lv.setUint32(0, 0x04034b50, true)
+    lv.setUint16(4, 20, true) // version
+    lv.setUint16(6, 0, true) // flags
+    lv.setUint16(8, 0, true) // no compression
+    lv.setUint16(10, modTime, true)
+    lv.setUint16(12, modDate, true)
+    lv.setUint32(14, crc, true)
+    lv.setUint32(18, data.length, true)
+    lv.setUint32(22, data.length, true)
+    lv.setUint16(26, nameBuf.length, true)
+    lv.setUint16(28, 0, true)
+    local.set(nameBuf, 30)
+
+    localParts.push(local, data)
+
+    const central = new Uint8Array(46 + nameBuf.length)
+    const cv = new DataView(central.buffer)
+    cv.setUint32(0, 0x02014b50, true)
+    cv.setUint16(4, 20, true)
+    cv.setUint16(6, 20, true)
+    cv.setUint16(8, 0, true)
+    cv.setUint16(10, 0, true)
+    cv.setUint16(12, modTime, true)
+    cv.setUint16(14, modDate, true)
+    cv.setUint32(16, crc, true)
+    cv.setUint32(20, data.length, true)
+    cv.setUint32(24, data.length, true)
+    cv.setUint16(28, nameBuf.length, true)
+    cv.setUint16(30, 0, true)
+    cv.setUint16(32, 0, true)
+    cv.setUint16(34, 0, true)
+    cv.setUint32(36, 0, true)
+    cv.setUint32(42, offset, true)
+    central.set(nameBuf, 46)
+
+    centralParts.push(central)
+    offset += local.length + data.length
+  }
+
+  const centralSize = centralParts.reduce((sum, p) => sum + p.length, 0)
+  const end = new Uint8Array(22)
+  const ev = new DataView(end.buffer)
+  ev.setUint32(0, 0x06054b50, true)
+  ev.setUint16(4, 0, true)
+  ev.setUint16(6, 0, true)
+  ev.setUint16(8, entries.length, true)
+  ev.setUint16(10, entries.length, true)
+  ev.setUint32(12, centralSize, true)
+  ev.setUint32(16, offset, true)
+  ev.setUint16(20, 0, true)
+
+  const blobParts = [...localParts, ...centralParts, end]
+  return new Blob(blobParts, { type: 'application/zip' })
+}


### PR DESCRIPTION
## Summary
- add memory detection utilities and simple ZIP generator
- enhance PDF demo with drag-and-drop upload, memory guardrails and splitting
- replace npm with pnpm in docs and tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683b9f646a1c8333975e746d73c691cd