### PR TITLE
Fix preview spawn on Windows

### DIFF
--- a/tests/production.test.js
+++ b/tests/production.test.js
@@ -17,7 +17,8 @@ test('README production steps work', async () => {
 
   // Preview command is available
   const result = spawnSync('pnpm', ['run', 'preview', '--', '--help'], {
-    stdio: 'inherit'
+    stdio: 'inherit',
+    shell: true
   })
   assert.strictEqual(result.status, 0, 'preview command failed')
 });


### PR DESCRIPTION
## Summary
- ensure `tests/production.test.js` spawns `pnpm` using the system shell

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683bc3b2dbb483338a80e44e5cd5d494