### PR TITLE
Add pdf-lib dependency and fix split test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "nuxt": "^3.17.4",
     "typescript": "^5.8.3",
     "vue": "^3.5.15",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "pdf-lib": "^1.18.1"
   },
   "devDependencies": {
     "@vite-pwa/nuxt": "^1.0.3"

--- a/tests/split.test.js
+++ b/tests/split.test.js
@@ -15,7 +15,7 @@ function splitEqual(data, parts) {
 }
 
 test('split pdf into equal parts', () => {
-  const pdfPath = path.join('samplePDFs', 'Dynamics 365 Business Central - Connectors _ Microsoft Learn.pdf');
+  const pdfPath = path.join('samplePDFs', 'sample.pdf');
   const buffer = fs.readFileSync(pdfPath);
   const data = new Uint8Array(buffer);
 


### PR DESCRIPTION
## Summary
- add `pdf-lib` as dependency
- fix sample path in split test to use `sample.pdf`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683bcdc2b6c083338330c8b3258d075a