### PR TITLE
Fix PDF splitting logic and tests

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,6 +66,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { getAvailableMemoryMB, computeMaxPdfSizeMB } from '~/utils/memory'
 import { createZip } from '~/utils/zip'
+import { splitPdfEqual, splitPdfBySize } from '~/utils/split'
 
 const isOnline = ref(true)
 const fileInput = ref<HTMLInputElement | null>(null)
@@ -141,24 +142,16 @@ function splitFile() {
   sections.value = []
   selectedSections.value = []
   if (splitMode.value === 'equal') {
-    const n = Math.max(1, equalParts.value)
-    const partSize = Math.ceil(data.length / n)
-    for (let i = 0; i < n; i++) {
-      const start = i * partSize
-      const end = Math.min(start + partSize, data.length)
-      const slice = data.slice(start, end)
-      sections.value.push({ name: `section-${i + 1}.pdf`, data: slice })
-    }
+    const parts = splitPdfEqual(data, equalParts.value)
+    parts.forEach((p, i) => {
+      sections.value.push({ name: `section-${i + 1}.pdf`, data: p })
+    })
   } else {
     const sizeBytes = Math.max(1, chunkSize.value) * 1024 * 1024
-    let offset = 0
-    let idx = 1
-    while (offset < data.length) {
-      const slice = data.slice(offset, offset + sizeBytes)
-      sections.value.push({ name: `section-${idx}.pdf`, data: slice })
-      offset += sizeBytes
-      idx++
-    }
+    const parts = splitPdfBySize(data, sizeBytes)
+    parts.forEach((p, i) => {
+      sections.value.push({ name: `section-${i + 1}.pdf`, data: p })
+    })
   }
 }
 

--- a/tests/split.test.js
+++ b/tests/split.test.js
@@ -1,25 +1,16 @@
-import test from 'node:test';
-import assert from 'node:assert';
-import fs from 'node:fs';
-import path from 'node:path';
+import test from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
 
-function splitEqual(data, parts) {
-  const partSize = Math.ceil(data.length / parts);
-  const result = [];
-  for (let i = 0; i < parts; i++) {
-    const start = i * partSize;
-    const end = Math.min(start + partSize, data.length);
-    result.push(data.slice(start, end));
-  }
-  return result;
-}
+import { splitPdfEqual } from '../utils/split.js'
 
 test('split pdf into equal parts', () => {
   const pdfPath = path.join('samplePDFs', 'sample.pdf');
   const buffer = fs.readFileSync(pdfPath);
   const data = new Uint8Array(buffer);
 
-  const parts = splitEqual(data, 3);
+  const parts = splitPdfEqual(data, 3);
   assert.strictEqual(parts.length, 3);
 
   const totalSize = parts.reduce((sum, p) => sum + p.length, 0);
@@ -29,4 +20,16 @@ test('split pdf into equal parts', () => {
   const maxSize = Math.max(...sizes);
   const minSize = Math.min(...sizes);
   assert.ok(maxSize - minSize <= 1, 'parts sizes vary too much');
+
+  const reconstructed = Buffer.concat(parts.map(p => Buffer.from(p)));
+  assert.ok(reconstructed.equals(Buffer.from(data)), 'reconstructed pdf mismatch');
+});
+
+test('no empty chunks when requesting many parts', () => {
+  const pdfPath = path.join('samplePDFs', 'sample.pdf');
+  const buffer = fs.readFileSync(pdfPath);
+  const data = new Uint8Array(buffer);
+
+  const parts = splitPdfEqual(data, data.length + 5);
+  assert.ok(parts.every(p => p.length > 0), 'contains empty parts');
 });

--- a/utils/split.js
+++ b/utils/split.js
@@ -1,0 +1,24 @@
+export function splitPdfEqual(data, parts) {
+  const result = []
+  const n = Math.max(1, Math.floor(parts))
+  const partSize = Math.ceil(data.length / n)
+  for (let i = 0; i < n; i++) {
+    const start = i * partSize
+    if (start >= data.length) break
+    const end = Math.min(start + partSize, data.length)
+    result.push(data.slice(start, end))
+  }
+  return result
+}
+
+export function splitPdfBySize(data, sizeBytes) {
+  const result = []
+  const chunk = Math.max(1, Math.floor(sizeBytes))
+  let offset = 0
+  while (offset < data.length) {
+    const end = Math.min(offset + chunk, data.length)
+    result.push(data.slice(offset, end))
+    offset += chunk
+  }
+  return result
+}


### PR DESCRIPTION
## Summary
- add utility helpers for splitting PDFs
- use helpers in the app for splitting by size or number of parts
- verify reconstructed PDF in tests
- ensure no empty sections when splitting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683bd4b793088333aa07406176ce8567