### PR TITLE
Fix PDF splitting

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -136,13 +136,13 @@ function parseFile() {
   reader.readAsArrayBuffer(selectedFile.value)
 }
 
-function splitFile() {
+async function splitFile() {
   if (!fileData.value) return
   const data = fileData.value
   sections.value = []
   selectedSections.value = []
   if (splitMode.value === 'equal') {
-    const parts = splitPdfEqual(data, equalParts.value)
+    const parts = await splitPdfEqual(data, equalParts.value)
     parts.forEach((p, i) => {
       sections.value.push({ name: `section-${i + 1}.pdf`, data: p })
     })

--- a/tests/split.test.js
+++ b/tests/split.test.js
@@ -6,34 +6,38 @@ import { PDFDocument } from 'pdf-lib'
 
 import { splitPdfEqual } from '../utils/split.js'
 
+// ensure each split piece is a valid PDF and page counts add up
+
 test('split pdf into equal parts', async () => {
-  const pdfPath = path.join('samplePDFs', 'sample.pdf');
-  const buffer = fs.readFileSync(pdfPath);
-  const data = new Uint8Array(buffer);
+  const pdfPath = path.join('samplePDFs', 'sample.pdf')
+  const buffer = fs.readFileSync(pdfPath)
+  const data = new Uint8Array(buffer)
 
-  const parts = splitPdfEqual(data, 3);
-  assert.strictEqual(parts.length, 3);
+  const original = await PDFDocument.load(data)
+  const originalPages = original.getPageCount()
 
-  const totalSize = parts.reduce((sum, p) => sum + p.length, 0);
-  assert.strictEqual(totalSize, data.length);
+  const parts = await splitPdfEqual(data, 3)
+  assert.strictEqual(parts.length, 3)
 
-  const sizes = parts.map(p => p.length);
-  const maxSize = Math.max(...sizes);
-  const minSize = Math.min(...sizes);
-  assert.ok(maxSize - minSize <= 1, 'parts sizes vary too much');
+  let pageSum = 0
+  for (const part of parts) {
+    const doc = await PDFDocument.load(part)
+    const count = doc.getPageCount()
+    assert.ok(count > 0, 'part has no pages')
+    pageSum += count
+  }
+  assert.strictEqual(pageSum, originalPages, 'page counts do not add up')
+})
 
-  const reconstructed = Buffer.concat(parts.map(p => Buffer.from(p)));
-  assert.ok(reconstructed.equals(Buffer.from(data)), 'reconstructed pdf mismatch');
+test('no empty chunks when requesting many parts', async () => {
+  const pdfPath = path.join('samplePDFs', 'sample.pdf')
+  const buffer = fs.readFileSync(pdfPath)
+  const data = new Uint8Array(buffer)
 
-  const pdfDoc = await PDFDocument.load(reconstructed)
-  assert.ok(pdfDoc.getPageCount() > 0, 'loaded pdf has no pages')
-});
+  const original = await PDFDocument.load(data)
+  const pages = original.getPageCount()
 
-test('no empty chunks when requesting many parts', () => {
-  const pdfPath = path.join('samplePDFs', 'sample.pdf');
-  const buffer = fs.readFileSync(pdfPath);
-  const data = new Uint8Array(buffer);
-
-  const parts = splitPdfEqual(data, data.length + 5);
-  assert.ok(parts.every(p => p.length > 0), 'contains empty parts');
-});
+  const parts = await splitPdfEqual(data, pages + 5)
+  assert.strictEqual(parts.length, pages)
+  assert.ok(parts.every(p => p.length > 0), 'contains empty parts')
+})

--- a/utils/split.js
+++ b/utils/split.js
@@ -1,12 +1,25 @@
-export function splitPdfEqual(data, parts) {
-  const result = []
+import { PDFDocument } from 'pdf-lib'
+
+/**
+ * Split a PDF into roughly equal parts by page count.
+ * Each returned Uint8Array represents a valid PDF document.
+ */
+export async function splitPdfEqual(data, parts) {
+  const pdfDoc = await PDFDocument.load(data)
+  const totalPages = pdfDoc.getPageCount()
   const n = Math.max(1, Math.floor(parts))
-  const partSize = Math.ceil(data.length / n)
-  for (let i = 0; i < n; i++) {
-    const start = i * partSize
-    if (start >= data.length) break
-    const end = Math.min(start + partSize, data.length)
-    result.push(data.slice(start, end))
+  const pagesPerPart = Math.ceil(totalPages / n)
+
+  const result = []
+  for (let start = 0; start < totalPages; start += pagesPerPart) {
+    const end = Math.min(start + pagesPerPart, totalPages)
+    const newDoc = await PDFDocument.create()
+    const indices = []
+    for (let i = start; i < end; i++) indices.push(i)
+    const pages = await newDoc.copyPages(pdfDoc, indices)
+    pages.forEach(p => newDoc.addPage(p))
+    const bytes = await newDoc.save()
+    result.push(new Uint8Array(bytes))
   }
   return result
 }


### PR DESCRIPTION
## Summary
- create a page-aware `splitPdfEqual` that produces valid PDFs
- await PDF splitting in the UI
- update tests to verify each part loads correctly

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683bdbb55d488333b5f555fd38983558