### PR TITLE
Fix PDF splitting by size

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -148,7 +148,7 @@ async function splitFile() {
     })
   } else {
     const sizeBytes = Math.max(1, chunkSize.value) * 1024 * 1024
-    const parts = splitPdfBySize(data, sizeBytes)
+    const parts = await splitPdfBySize(data, sizeBytes)
     parts.forEach((p, i) => {
       sections.value.push({ name: `section-${i + 1}.pdf`, data: p })
     })

--- a/tests/split.test.js
+++ b/tests/split.test.js
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { PDFDocument } from 'pdf-lib'
 
-import { splitPdfEqual } from '../utils/split.js'
+import { splitPdfEqual, splitPdfBySize } from '../utils/split.js'
 
 // ensure each split piece is a valid PDF and page counts add up
 
@@ -40,4 +40,25 @@ test('no empty chunks when requesting many parts', async () => {
   const parts = await splitPdfEqual(data, pages + 5)
   assert.strictEqual(parts.length, pages)
   assert.ok(parts.every(p => p.length > 0), 'contains empty parts')
+})
+
+test('split pdf by size yields valid pdfs', async () => {
+  const pdfPath = path.join('samplePDFs', 'sample.pdf')
+  const buffer = fs.readFileSync(pdfPath)
+  const data = new Uint8Array(buffer)
+
+  const original = await PDFDocument.load(data)
+  const originalPages = original.getPageCount()
+
+  const parts = await splitPdfBySize(data, 300 * 1024)
+  assert.ok(parts.length > 1, 'should produce multiple parts')
+
+  let pageSum = 0
+  for (const part of parts) {
+    const doc = await PDFDocument.load(part)
+    const count = doc.getPageCount()
+    assert.ok(count > 0, 'part has no pages')
+    pageSum += count
+  }
+  assert.strictEqual(pageSum, originalPages, 'page counts do not add up')
 })

--- a/utils/split.js
+++ b/utils/split.js
@@ -24,14 +24,49 @@ export async function splitPdfEqual(data, parts) {
   return result
 }
 
-export function splitPdfBySize(data, sizeBytes) {
+export async function splitPdfBySize(data, sizeBytes) {
+  const limit = Math.max(1, Math.floor(sizeBytes))
+  const pdfDoc = await PDFDocument.load(data)
+  const totalPages = pdfDoc.getPageCount()
   const result = []
-  const chunk = Math.max(1, Math.floor(sizeBytes))
-  let offset = 0
-  while (offset < data.length) {
-    const end = Math.min(offset + chunk, data.length)
-    result.push(data.slice(offset, end))
-    offset += chunk
+
+  let index = 0
+  while (index < totalPages) {
+    const newDoc = await PDFDocument.create()
+    let bytes = null
+    let pagesAdded = 0
+
+    while (index < totalPages) {
+      const [page] = await newDoc.copyPages(pdfDoc, [index])
+      newDoc.addPage(page)
+      pagesAdded++
+      bytes = await newDoc.save()
+
+      if (bytes.byteLength > limit) {
+        if (pagesAdded > 1) {
+          newDoc.removePage(newDoc.getPageCount() - 1)
+          bytes = await newDoc.save()
+          result.push(new Uint8Array(bytes))
+          pagesAdded--
+        } else {
+          result.push(new Uint8Array(bytes))
+          index++
+        }
+        break
+      }
+
+      index++
+      if (index >= totalPages) {
+        result.push(new Uint8Array(bytes))
+        break
+      }
+    }
+
+    if (pagesAdded === 0) {
+      // ensure progress to avoid infinite loop when a single page exceeds limit
+      index++
+    }
   }
+
   return result
 }


### PR DESCRIPTION
## Summary
- fix `splitPdfBySize` to produce valid PDFs
- adjust index page to await updated function
- add tests ensuring PDF chunks remain valid when splitting by size

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683c5dbd58e48333a4c3f52c07cd3cad