### PR TITLE
Add test for reading split PDFs from disk

### DIFF
--- a/tests/split.test.js
+++ b/tests/split.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { PDFDocument } from 'pdf-lib'
 
@@ -61,4 +62,25 @@ test('split pdf by size yields valid pdfs', async () => {
     pageSum += count
   }
   assert.strictEqual(pageSum, originalPages, 'page counts do not add up')
+})
+
+test('downloaded split pdf can be opened from disk', async () => {
+  const pdfPath = path.join('samplePDFs', 'sample.pdf')
+  const buffer = fs.readFileSync(pdfPath)
+  const data = new Uint8Array(buffer)
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'split-'))
+  const parts = await splitPdfEqual(data, 2)
+
+  for (const [i, part] of parts.entries()) {
+    const file = path.join(tmpDir, `part-${i + 1}.pdf`)
+    fs.writeFileSync(file, part)
+    const bytes = fs.readFileSync(file)
+    const doc = await PDFDocument.load(bytes)
+    const count = doc.getPageCount()
+    assert.ok(count > 0, 'downloaded part has no pages')
+    fs.unlinkSync(file)
+  }
+
+  fs.rmSync(tmpDir, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Summary
- ensure Node tests handle PDF downloads by writing split PDFs to temp files

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683c5f53f3388333aa5ca626e418b849