### PR TITLE
Fix service worker caching error

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -9,7 +9,15 @@ const ASSETS = [
 ];
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then(async cache => {
+      for (const asset of ASSETS) {
+        try {
+          await cache.add(new Request(asset, {mode: 'no-cors'}));
+        } catch (err) {
+          console.warn('SW cache failed for', asset, err);
+        }
+      }
+    })
   );
 });
 self.addEventListener('fetch', event => {


### PR DESCRIPTION
## Summary
- fix offline asset caching to avoid unhandled rejection

## Testing
- `node --check service-worker.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6848fda484508333bd3aad24437ba4ec