### PR TITLE
Add debug memory limit override

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ BrainPDF is a local‑first toolkit for splitting and exporting large PDF docume
 Open `index.html` in a modern browser. The service worker will cache assets after the first load so you can use the app offline.
 
 The main logic lives in `main.js`. Plugins can call `registerPlugin(fn)` where `fn` is an async function that receives an array of output objects to modify or add files before export.
+
+## Developer / QA tips
+### Force a tiny upload limit
+When testing the oversize-file guardrail on machines with plenty of RAM, add
+`?maxUploadMB=<number>` to the URL, e.g.  
+`https://brianbrainium.github.io/BrainPDF/?maxUploadMB=10`  
+The banner will show "(debug override)", and uploads above that value will be
+rejected. Remove the query string to return to automatic detection.

--- a/main.js
+++ b/main.js
@@ -23,15 +23,27 @@ let toc = [];
 const PARSE_OVERHEAD_MB = 200;          // reserved head-room for parsing
 let   maxUploadMB       = null;         // computed at runtime
 
+// ---------- DEBUG override via query param -------------------------------
+function getDebugMaxUpload () {
+  const params = new URLSearchParams(window.location.search);
+  const raw    = params.get('maxUploadMB');
+  if (!raw) return null;
+  const val = parseInt(raw, 10);
+  return Number.isFinite(val) && val > 0 ? val : null;
+}
+const DEBUG_OVERRIDE_MB = getDebugMaxUpload();
+
 function updateMemoryInfo () {
   const memGB   = navigator.deviceMemory || 0;     // may be 0/undefined
   const availMB = memGB ? memGB * 1024 : 0;
-  maxUploadMB   = availMB ? Math.max(availMB - PARSE_OVERHEAD_MB, 0) : null;
+  maxUploadMB = DEBUG_OVERRIDE_MB ??
+                (availMB ? Math.max(availMB - PARSE_OVERHEAD_MB, 0) : null);
 
   const availStr = availMB ? `${availMB} MB` : 'unknown';
   const maxStr   = maxUploadMB !== null ? `${maxUploadMB} MB` : 'unknown';
   memoryInfo.textContent =
-    `Approx. available memory: ${availStr}. Maximum safe upload: ${maxStr}.`;
+    `Approx. available memory: ${availStr}. Maximum safe upload: ${maxStr}` +
+    (DEBUG_OVERRIDE_MB ? ' (debug override).' : '.');
 }
 updateMemoryInfo();
 document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
## Summary
- allow overriding `maxUploadMB` via `?maxUploadMB=<number>` query param
- document the debug override in the readme

## Testing
- `npm run lint` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685391fd80bc8333bd11969405256496