### PR TITLE
Add half-page parsing helper and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore user files
 *.zip
+node_modules/
+package-lock.json

--- a/issues/2025-07-04-parse-half-pages.md
+++ b/issues/2025-07-04-parse-half-pages.md
@@ -1,0 +1,3 @@
+# Parse uploaded file only halfway for test
+
+Implement a feature to load and parse only the first half of pages from an uploaded PDF for testing purposes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "brainpdf",
+  "version": "1.0.0",
+  "description": "BrainPDF is a local‑first toolkit for splitting and exporting large PDF documents right in the browser. It works completely offline as a Progressive Web App (PWA) so your files never leave your machine.",
+  "main": "main.js",
+  "scripts": {
+    "test": "node tests/parseHalf.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "pdf-lib": "^1.17.1"
+  }
+}

--- a/parseHalf.js
+++ b/parseHalf.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const { PDFDocument } = require('pdf-lib');
+
+/**
+ * Extract the first half of pages from a PDF file.
+ * @param {Uint8Array|Buffer} pdfBytes - The PDF file bytes.
+ * @returns {Promise<Uint8Array>} Bytes of the half-page PDF.
+ */
+async function extractHalf(pdfBytes) {
+  const doc = await PDFDocument.load(pdfBytes);
+  const total = doc.getPageCount();
+  const halfCount = Math.ceil(total / 2);
+  const newPdf = await PDFDocument.create();
+  const pages = await newPdf.copyPages(doc, Array.from({ length: halfCount }, (_, i) => i));
+  pages.forEach(p => newPdf.addPage(p));
+  return await newPdf.save();
+}
+
+module.exports = { extractHalf };

--- a/tests/parseHalf.test.js
+++ b/tests/parseHalf.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const { PDFDocument } = require('pdf-lib');
+const { extractHalf } = require('../parseHalf');
+
+(async () => {
+  const data = fs.readFileSync('testPDF.pdf');
+  const doc = await PDFDocument.load(data);
+  const total = doc.getPageCount();
+  const halfBytes = await extractHalf(data);
+  const halfDoc = await PDFDocument.load(halfBytes);
+  const halfPages = halfDoc.getPageCount();
+  if (halfPages !== Math.ceil(total / 2)) {
+    console.error(`Expected ${Math.ceil(total / 2)} pages, got ${halfPages}`);
+    process.exit(1);
+  }
+  console.log('parseHalf test passed.');
+})();


### PR DESCRIPTION
## Summary
- add `parseHalf.js` helper to produce a PDF consisting of the first half of the pages of an input
- create a Node-based test that uses `testPDF.pdf` to verify this behaviour
- add simple `package.json` and `.gitignore` entries for Node usage
- document new task in `issues/2025-07-04-parse-half-pages.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68684882b6448333b78cf1f4fb33b04b