### PR TITLE
Add browser test page for half-page parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ only the first half of pages from a PDF for testing purposes.
 
 Run `npm test` to execute the included Node script which verifies the half-page
 parsing helper.
+You can also open `half-test.html` in the browser and select a PDF to download
+the first half of its pages.

--- a/half-test.html
+++ b/half-test.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Half-page Parser Test</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Half-page Parser Test</h1>
+  <input type="file" id="pdf-input" accept="application/pdf" />
+  <button id="parse-btn">Parse Half</button>
+  <a id="download-link" style="display:none"></a>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
+  <script>
+    async function parseHalf(file) {
+      const buf = new Uint8Array(await file.arrayBuffer());
+      const doc = await PDFLib.PDFDocument.load(buf);
+      const total = doc.getPageCount();
+      const half = Math.ceil(total / 2);
+      const out = await PDFLib.PDFDocument.create();
+      const pages = await out.copyPages(doc, Array.from({length: half}, (_, i) => i));
+      pages.forEach(p => out.addPage(p));
+      const data = await out.save();
+      return { bytes: data, pages: half };
+    }
+
+    document.getElementById('parse-btn').addEventListener('click', async () => {
+      const input = document.getElementById('pdf-input');
+      if (!input.files.length) {
+        alert('Please select a PDF file first.');
+        return;
+      }
+      const { bytes, pages } = await parseHalf(input.files[0]);
+      const blob = new Blob([bytes], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      const link = document.getElementById('download-link');
+      link.href = url;
+      link.download = 'half.pdf';
+      link.textContent = `Download first ${pages} pages`;
+      link.style.display = 'inline';
+    });
+  </script>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,6 +2,7 @@ const CACHE_NAME = 'brainpdf-cache-v1';
 const ASSETS = [
   '/',
   '/index.html',
+  '/half-test.html',
   '/style.css',
   '/main.js',
   '/ocr-plugin.js',


### PR DESCRIPTION
## Summary
- add `half-test.html` page to test half-page PDF parsing in browser
- cache the new page in `service-worker.js`
- document the page in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686851a794bc8333ad5b10c3ef0c1b24