### PR TITLE
Add TOC inspector page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ BrainPDF is a local‑first toolkit for splitting and exporting large PDF docume
 - **Plugin API** – register custom actions such as OCR or summarisation.
 - **Built-in OCR plugin** – extract text from scanned PDFs on export.
 - **Half-page parsing helper** – load only the first half of a PDF for tests.
+- **TOC Inspector** – standalone page to check if a PDF's table of contents is
+  recognised.
 
 ## Development
 
 Open `index.html` in a modern browser. The service worker will cache assets after the first load so you can use the app offline.
+For a quick check that a PDF's outline is compatible, open `toc-inspector.html` and upload your file.
 
 The main logic lives in `main.js`. Plugins can call `registerPlugin(fn)` where `fn` is an async function that receives an array of output objects to modify or add files before export.
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,8 +2,10 @@ const CACHE_NAME = 'brainpdf-cache-v1';
 const ASSETS = [
   '/',
   '/index.html',
+  '/toc-inspector.html',
   '/style.css',
   '/main.js',
+  '/toc-inspector.js',
   '/ocr-plugin.js',
   'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js',
   'https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js',
@@ -28,3 +30,4 @@ self.addEventListener('fetch', event => {
     caches.match(event.request).then(res => res || fetch(event.request))
   );
 });
+

--- a/toc-inspector.html
+++ b/toc-inspector.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BrainPDF – TOC Inspector</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>BrainPDF – TOC Inspector</h1>
+  <input type="file" id="file-input" accept="application/pdf" />
+  <div id="drop-zone">Drop PDF here</div>
+  <progress id="parse-progress" value="0" max="100" style="display:none"></progress>
+  <div id="result"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js"></script>
+  <script type="module" src="toc-inspector.js"></script>
+</body>
+</html>

--- a/toc-inspector.js
+++ b/toc-inspector.js
@@ -1,0 +1,51 @@
+const fileInput = document.getElementById('file-input');
+const dropZone  = document.getElementById('drop-zone');
+const result    = document.getElementById('result');
+const progress  = document.getElementById('parse-progress');
+
+function handleFile(file) {
+  if (!file) return;
+  progress.style.display = 'block';
+  progress.value = 0;
+  const reader = new FileReader();
+  reader.onload = async () => {
+    try {
+      const typedarray = new Uint8Array(reader.result);
+      const pdfDoc = await pdfjsLib.getDocument({ data: typedarray }).promise;
+      progress.value = 50;
+      const outline = await pdfDoc.getOutline();
+      progress.value = 100;
+      if (!outline) {
+        result.textContent = 'No Table of Contents found.';
+      } else {
+        const ul = document.createElement('ul');
+        outline.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = item.title;
+          ul.appendChild(li);
+        });
+        result.innerHTML = '<strong>TOC detected:</strong>';
+        result.appendChild(ul);
+      }
+    } catch (err) {
+      result.textContent = 'Error parsing PDF: ' + err.message;
+    } finally {
+      progress.style.display = 'none';
+    }
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+fileInput.addEventListener('change', e => handleFile(e.target.files[0]));
+
+['dragenter','dragover'].forEach(ev => dropZone.addEventListener(ev, e => {
+  e.preventDefault();
+  dropZone.classList.add('dragover');
+}));
+['dragleave','drop'].forEach(ev => dropZone.addEventListener(ev, e => {
+  e.preventDefault();
+  dropZone.classList.remove('dragover');
+}));
+
+dropZone.addEventListener('drop', e => handleFile(e.dataTransfer.files[0]));
+


### PR DESCRIPTION
## Summary
- create `toc-inspector.html` standalone page
- add parsing logic in `toc-inspector.js`
- cache new assets in the service worker
- document new feature in `README`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686851eaed2c8333923b57984cee82d1