### PR TITLE
Add memory usage test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,15 @@ BrainPDF is a local‑first toolkit for splitting and exporting large PDF docume
 - **Plugin API** – register custom actions such as OCR or summarisation.
 - **Built-in OCR plugin** – extract text from scanned PDFs on export.
 - **Half-page parsing helper** – load only the first half of a PDF for tests.
+- **Memory usage test page** – measure processing memory to refine upload limits.
 
 ## Development
 
 Open `index.html` in a modern browser. The service worker will cache assets after the first load so you can use the app offline.
 
 The main logic lives in `main.js`. Plugins can call `registerPlugin(fn)` where `fn` is an async function that receives an array of output objects to modify or add files before export.
+
+To estimate how much memory your device uses when opening a PDF, open `memory.html`. After selecting a test document the page will display the memory consumed during parsing and the recommended maximum upload size.
 
 ## Developer / QA tips
 ### Force a tiny upload limit

--- a/memory.html
+++ b/memory.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PDF Memory Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>PDF Memory Usage</h1>
+  <p>Use this page to gauge how much memory is consumed when processing a PDF.</p>
+  <input type="file" id="mem-file" accept="application/pdf" />
+  <pre id="mem-report"></pre>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js"></script>
+  <script type="module" src="memory.js"></script>
+</body>
+</html>

--- a/memory.js
+++ b/memory.js
@@ -1,0 +1,38 @@
+const fileInput = document.getElementById('mem-file');
+const report    = document.getElementById('mem-report');
+
+function formatBytes(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+}
+
+async function measureMemory(file) {
+  if (!performance.memory) {
+    report.textContent = 'performance.memory API not available in this browser.';
+    return;
+  }
+  const before = performance.memory.usedJSHeapSize;
+  const arrayBuffer = await file.arrayBuffer();
+  const typedarray = new Uint8Array(arrayBuffer);
+  await pdfjsLib.getDocument({ data: typedarray }).promise;
+  const after = performance.memory.usedJSHeapSize;
+  const delta = after - before;
+
+  const deviceMemGB = navigator.deviceMemory || 0;
+  const availMB = deviceMemGB ? deviceMemGB * 1024 : 0;
+  const overheadMB = delta / (1024 * 1024);
+  const maxUploadMB = availMB
+    ? Math.max(availMB - overheadMB, 0).toFixed(2)
+    : 'unknown';
+
+  const availStr = availMB ? availMB.toFixed(2) + ' MB' : 'unknown';
+
+  report.textContent =
+    `Used memory: ${formatBytes(delta)}\n` +
+    `Approx. available memory: ${availStr}\n` +
+    `Recommended maximum upload: ${maxUploadMB} MB`;
+}
+
+fileInput.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (file) measureMemory(file);
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,6 +4,8 @@ const ASSETS = [
   '/index.html',
   '/style.css',
   '/main.js',
+  '/memory.html',
+  '/memory.js',
   '/ocr-plugin.js',
   'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js',
   'https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js',


### PR DESCRIPTION
## Summary
- add page to measure memory consumed when processing a PDF
- cache new page in service worker
- document the new feature

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868524a2a2c8333b93742b8ba1bc661