### PR TITLE
Show both halves in parser

### DIFF
--- a/half-test.html
+++ b/half-test.html
@@ -13,21 +13,31 @@
   </nav>
   <h1>Half-page Parser Test</h1>
   <input type="file" id="pdf-input" accept="application/pdf" />
-  <button id="parse-btn">Parse Half</button>
-  <a id="download-link" style="display:none"></a>
+  <button id="parse-btn">Parse Halves</button>
+  <div id="halves-container"></div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
   <script>
-    async function parseHalf(file) {
+    async function splitHalves(file) {
       const buf = new Uint8Array(await file.arrayBuffer());
       const doc = await PDFLib.PDFDocument.load(buf);
       const total = doc.getPageCount();
       const half = Math.ceil(total / 2);
-      const out = await PDFLib.PDFDocument.create();
-      const pages = await out.copyPages(doc, Array.from({length: half}, (_, i) => i));
-      pages.forEach(p => out.addPage(p));
-      const data = await out.save();
-      return { bytes: data, pages: half };
+
+      const first = await PDFLib.PDFDocument.create();
+      const firstPages = await first.copyPages(doc, Array.from({ length: half }, (_, i) => i));
+      firstPages.forEach(p => first.addPage(p));
+
+      const second = await PDFLib.PDFDocument.create();
+      const secondPages = await second.copyPages(doc, Array.from({ length: total - half }, (_, i) => i + half));
+      secondPages.forEach(p => second.addPage(p));
+
+      return {
+        firstBytes: await first.save(),
+        secondBytes: await second.save(),
+        firstPages: half,
+        secondPages: total - half,
+      };
     }
 
     document.getElementById('parse-btn').addEventListener('click', async () => {
@@ -36,14 +46,20 @@
         alert('Please select a PDF file first.');
         return;
       }
-      const { bytes, pages } = await parseHalf(input.files[0]);
-      const blob = new Blob([bytes], { type: 'application/pdf' });
-      const url = URL.createObjectURL(blob);
-      const link = document.getElementById('download-link');
-      link.href = url;
-      link.download = 'half.pdf';
-      link.textContent = `Download first ${pages} pages`;
-      link.style.display = 'inline';
+      const { firstBytes, secondBytes } = await splitHalves(input.files[0]);
+      const container = document.getElementById('halves-container');
+      container.innerHTML = '';
+
+      [firstBytes, secondBytes].forEach(bytes => {
+        const blob = new Blob([bytes], { type: 'application/pdf' });
+        const url = URL.createObjectURL(blob);
+        const frame = document.createElement('iframe');
+        frame.src = url;
+        frame.width = '100%';
+        frame.height = '400';
+        frame.style.marginTop = '1rem';
+        container.appendChild(frame);
+      });
     });
   </script>
   <script>

--- a/parseHalf.js
+++ b/parseHalf.js
@@ -16,4 +16,28 @@ async function extractHalf(pdfBytes) {
   return await newPdf.save();
 }
 
-module.exports = { extractHalf };
+/**
+ * Split a PDF file into two halves.
+ * @param {Uint8Array|Buffer} pdfBytes - The PDF file bytes.
+ * @returns {Promise<{first: Uint8Array, second: Uint8Array}>} Bytes for each half.
+ */
+async function extractHalves(pdfBytes) {
+  const doc = await PDFDocument.load(pdfBytes);
+  const total = doc.getPageCount();
+  const halfCount = Math.ceil(total / 2);
+
+  const firstPdf = await PDFDocument.create();
+  const firstPages = await firstPdf.copyPages(doc, Array.from({ length: halfCount }, (_, i) => i));
+  firstPages.forEach(p => firstPdf.addPage(p));
+
+  const secondPdf = await PDFDocument.create();
+  const secondPages = await secondPdf.copyPages(doc, Array.from({ length: total - halfCount }, (_, i) => i + halfCount));
+  secondPages.forEach(p => secondPdf.addPage(p));
+
+  return {
+    first: await firstPdf.save(),
+    second: await secondPdf.save(),
+  };
+}
+
+module.exports = { extractHalf, extractHalves };

--- a/tests/parseHalf.test.js
+++ b/tests/parseHalf.test.js
@@ -1,17 +1,22 @@
 const fs = require('fs');
 const { PDFDocument } = require('pdf-lib');
-const { extractHalf } = require('../parseHalf');
+const { extractHalves } = require('../parseHalf');
 
 (async () => {
   const data = fs.readFileSync('testPDF.pdf');
   const doc = await PDFDocument.load(data);
   const total = doc.getPageCount();
-  const halfBytes = await extractHalf(data);
-  const halfDoc = await PDFDocument.load(halfBytes);
-  const halfPages = halfDoc.getPageCount();
-  if (halfPages !== Math.ceil(total / 2)) {
-    console.error(`Expected ${Math.ceil(total / 2)} pages, got ${halfPages}`);
+  const { first, second } = await extractHalves(data);
+  const firstDoc = await PDFDocument.load(first);
+  const secondDoc = await PDFDocument.load(second);
+  const half = Math.ceil(total / 2);
+  if (firstDoc.getPageCount() !== half) {
+    console.error(`Expected first half to have ${half} pages, got ${firstDoc.getPageCount()}`);
     process.exit(1);
   }
-  console.log('parseHalf test passed.');
+  if (secondDoc.getPageCount() !== total - half) {
+    console.error(`Expected second half to have ${total - half} pages, got ${secondDoc.getPageCount()}`);
+    process.exit(1);
+  }
+  console.log('parseHalves test passed.');
 })();


### PR DESCRIPTION
## Summary
- update half test page to display both halves instead of just the first half
- extend `parseHalf.js` with `extractHalves` and export it
- adjust tests to verify both halves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68685e9c49ac8333802676d5c36670d4