### PR TITLE
Fix progress bar freeze for large PDFs

### DIFF
--- a/pages/page-1.html
+++ b/pages/page-1.html
@@ -42,6 +42,7 @@
         const pageText = content.items.map(it => it.str).join(' ');
         text += pageText + '\n';
         progress.value = (i / pdf.numPages) * 100;
+        await new Promise(r => setTimeout(r, 0));
       }
       progress.style.display = 'none';
       document.getElementById('text-output').textContent = text;


### PR DESCRIPTION
## Summary
- yield to the browser event loop while processing each page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868697f27188333874a73c1d08ecf71