### PR TITLE
Add page chunk splitting for PDFs

### DIFF
--- a/half-test.html
+++ b/half-test.html
@@ -15,40 +15,39 @@
     <a href="pages/page-2.html">TOC Viewer</a>
     <a href="pages/page-3.html">Size Checker</a>
   </nav>
-  <h1>Half-page Parser Test</h1>
+  <h1>Page Chunk Parser Test</h1>
   <input type="file" id="pdf-input" accept="application/pdf" />
-  <button id="parse-btn">Parse Halves</button>
+  <label>Pages per chunk: <input type="number" id="page-limit" value="100" min="1" /></label>
+  <button id="parse-btn">Parse</button>
+  <div id="file-size"></div>
   <progress id="upload-progress" value="0" max="100" style="display:none"></progress>
   <progress id="parse-progress" value="0" max="100" style="display:none"></progress>
   <div id="halves-container"></div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
   <script>
-    async function splitHalves(buffer, progressCb) {
+    function formatMB(bytes) {
+      return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+    }
+
+    async function splitChunks(buffer, limit, progressCb) {
       if (progressCb) progressCb(10);
       const doc = await PDFLib.PDFDocument.load(buffer);
       if (progressCb) progressCb(20);
       const total = doc.getPageCount();
-      const half = Math.ceil(total / 2);
-
-      const first = await PDFLib.PDFDocument.create();
-      const firstPages = await first.copyPages(doc, Array.from({ length: half }, (_, i) => i));
-      firstPages.forEach(p => first.addPage(p));
-      if (progressCb) progressCb(50);
-
-      const second = await PDFLib.PDFDocument.create();
-      const secondPages = await second.copyPages(doc, Array.from({ length: total - half }, (_, i) => i + half));
-      secondPages.forEach(p => second.addPage(p));
-      if (progressCb) progressCb(80);
-
-      const result = {
-        firstBytes: await first.save(),
-        secondBytes: await second.save(),
-        firstPages: half,
-        secondPages: total - half,
-      };
+      const chunks = [];
+      let processed = 0;
+      while (processed < total) {
+        const count = Math.min(limit, total - processed);
+        const part = await PDFLib.PDFDocument.create();
+        const pages = await part.copyPages(doc, Array.from({ length: count }, (_, j) => processed + j));
+        pages.forEach(p => part.addPage(p));
+        chunks.push(await part.save());
+        processed += count;
+        if (progressCb) progressCb(20 + (processed / total) * 80);
+      }
       if (progressCb) progressCb(100);
-      return result;
+      return { chunks, total };
     }
 
     document.getElementById('parse-btn').addEventListener('click', () => {
@@ -59,6 +58,8 @@
       }
 
       const file = input.files[0];
+      document.getElementById('file-size').textContent = `File size: ${formatMB(file.size)}`;
+      const limit = parseInt(document.getElementById('page-limit').value, 10) || 1;
       const uploadBar = document.getElementById('upload-progress');
       const parseBar = document.getElementById('parse-progress');
 
@@ -79,7 +80,7 @@
         parseBar.value = 0;
 
         const buffer = new Uint8Array(reader.result);
-        const { firstBytes, secondBytes } = await splitHalves(buffer, pct => {
+        const { chunks } = await splitChunks(buffer, limit, pct => {
           parseBar.value = pct;
         });
 
@@ -88,7 +89,7 @@
         const container = document.getElementById('halves-container');
         container.innerHTML = '';
 
-        [firstBytes, secondBytes].forEach(bytes => {
+        chunks.forEach(bytes => {
           const blob = new Blob([bytes], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);
           const frame = document.createElement('iframe');
@@ -96,6 +97,9 @@
           frame.width = '100%';
           frame.height = '400';
           frame.style.marginTop = '1rem';
+          const sizeInfo = document.createElement('div');
+          sizeInfo.textContent = `Chunk size: ${formatMB(bytes.byteLength)}`;
+          container.appendChild(sizeInfo);
           container.appendChild(frame);
         });
       };

--- a/parseHalf.js
+++ b/parseHalf.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const { PDFDocument } = require('pdf-lib');
 
 /**
@@ -40,4 +39,24 @@ async function extractHalves(pdfBytes) {
   };
 }
 
-module.exports = { extractHalf, extractHalves };
+/**
+ * Split a PDF file into chunks with a maximum number of pages per chunk.
+ * @param {Uint8Array|Buffer} pdfBytes - The PDF file bytes.
+ * @param {number} limit - Maximum pages per chunk.
+ * @returns {Promise<Uint8Array[]>} Array of PDF bytes for each chunk.
+ */
+async function splitByPageCount(pdfBytes, limit) {
+  const doc = await PDFDocument.load(pdfBytes);
+  const total = doc.getPageCount();
+  const chunks = [];
+  for (let i = 0; i < total; i += limit) {
+    const count = Math.min(limit, total - i);
+    const newPdf = await PDFDocument.create();
+    const pages = await newPdf.copyPages(doc, Array.from({ length: count }, (_, j) => i + j));
+    pages.forEach(p => newPdf.addPage(p));
+    chunks.push(await newPdf.save());
+  }
+  return chunks;
+}
+
+module.exports = { extractHalf, extractHalves, splitByPageCount };

--- a/tests/parseHalf.test.js
+++ b/tests/parseHalf.test.js
@@ -1,22 +1,25 @@
 const fs = require('fs');
 const { PDFDocument } = require('pdf-lib');
-const { extractHalves } = require('../parseHalf');
+const { splitByPageCount } = require('../parseHalf');
 
 (async () => {
   const data = fs.readFileSync('testPDF.pdf');
   const doc = await PDFDocument.load(data);
   const total = doc.getPageCount();
-  const { first, second } = await extractHalves(data);
-  const firstDoc = await PDFDocument.load(first);
-  const secondDoc = await PDFDocument.load(second);
-  const half = Math.ceil(total / 2);
-  if (firstDoc.getPageCount() !== half) {
-    console.error(`Expected first half to have ${half} pages, got ${firstDoc.getPageCount()}`);
+  const chunks = await splitByPageCount(data, 100);
+  let sum = 0;
+  for (const chunk of chunks) {
+    const docChunk = await PDFDocument.load(chunk);
+    const pages = docChunk.getPageCount();
+    if (pages > 100) {
+      console.error(`Chunk exceeds limit: ${pages} pages`);
+      process.exit(1);
+    }
+    sum += pages;
+  }
+  if (sum !== total) {
+    console.error(`Expected ${total} total pages from chunks, got ${sum}`);
     process.exit(1);
   }
-  if (secondDoc.getPageCount() !== total - half) {
-    console.error(`Expected second half to have ${total - half} pages, got ${secondDoc.getPageCount()}`);
-    process.exit(1);
-  }
-  console.log('parseHalves test passed.');
+  console.log('splitByPageCount test passed.');
 })();


### PR DESCRIPTION
## Summary
- generalize half page extraction with `splitByPageCount`
- show file size and chunk sizes in the example HTML
- update tests for the new function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68686b26b480833386683235d4c32cad