### PR TITLE
Fix PDF memory usage calculation

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -15,8 +15,10 @@ async function measureMemory(file) {
   const typedarray = new Uint8Array(arrayBuffer);
   const pdfDoc = await pdfjsLib.getDocument({ data: typedarray }).promise;
   const after = performance.memory.usedJSHeapSize;
-  const delta = after - before;
+  const measured = after - before;
   await pdfDoc.destroy();
+
+  const delta = measured > 0 ? measured : file.size;
 
   const deviceMemGB = navigator.deviceMemory || 0;
   const availMB = deviceMemGB ? deviceMemGB * 1024 : 0;
@@ -28,7 +30,8 @@ async function measureMemory(file) {
   const availStr = availMB ? availMB.toFixed(2) + ' MB' : 'unknown';
 
   report.textContent =
-    `Used memory: ${formatBytes(delta)}\n` +
+    `File size: ${formatBytes(file.size)}\n` +
+    `Estimated used memory: ${formatBytes(delta)}\n` +
     `Approx. available memory: ${availStr}\n` +
     `Recommended maximum upload: ${maxUploadMB} MB`;
 }


### PR DESCRIPTION
## Summary
- improve memory usage estimation by falling back to file size
- show file size in memory usage report

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68686c04160883339e5e79a60a974703